### PR TITLE
Add Github Action for Ansible Galaxy release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+# This GitHub action can publish assets for release when a tag is created.
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+
+name: release
+on:
+  workflow_dispatch: null
+  release:
+    types: [ published ]
+jobs:
+  galaxyrelease:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .ansible/collections/ansible_collections/equinix/cloud
+    environment: 'METAL_API_TOKEN'
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: .ansible/collections/ansible_collections/equinix/cloud
+
+      - name: update packages
+        run: sudo apt-get update -y
+
+      - name: install make
+        run: sudo apt-get install -y build-essential
+
+      - name: setup python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: install dependencies
+        run: pip3 install -r requirements-dev.txt -r requirements.txt
+
+      - name: publish the collection
+        run: make publish
+        env:
+          GALAXY_TOKEN: ${{ secrets.GALAXY_TOKEN }}
+          COLLECTION_VERSION: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This PR adds a workflow for releases. 

This still needs:
- @displague please log in to https://galaxy.ansible.com/accounts/login/ with Equinix creadentials and create collection `equinix.cloud`
- acquire GALAXY_TOKEN that can add releases to the `equinix.cloud` collection
- Add GALAXY_TOKEN to the METAL_API_TOKEN Gtihub Actions env (and maybe consider renaming the METAL_API_TOKEN env)

Anyway, this is one of the things that we won't know if it works until we try.