### PR TITLE
Remove aws collection dependency from integration test Github action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,9 +31,6 @@ jobs:
       - name: install dependencies
         run: python -m pip install -r requirements-dev.txt -r requirements.txt
 
-      - name: install ansible dependencies
-        run: ansible-galaxy collection install amazon.aws:==1.5.1
-
       - name: install collection
         run: make install
 


### PR DESCRIPTION
This is to test if we need the aws collection for anything.

