### PR TITLE
bump equinix_metal pip dependency to v0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-equinix-metal>=0.1.0
+equinix-metal>=0.2.0
 ansible-specdoc>=0.0.13


### PR DESCRIPTION
We've just released v0.2.0 of metal-python (equinix_metal) 
https://github.com/equinix-labs/metal-python/releases/tag/v0.2.0
.. which adds support for more resources. 

We need to bump the dep, and :crossed_fingers: for integration test success