### PR TITLE
remove requirements from module docs

### DIFF
--- a/plugins/module_utils/equinix.py
+++ b/plugins/module_utils/equinix.py
@@ -218,10 +218,6 @@ def getSpecDocMeta(short_description, description, options, examples, return_val
         examples=examples,
         return_values=return_values,
         author='Equinix DevRel Team (@equinix) <support@equinix.com>',
-        requirements=[
-            'python >= 3',
-            'equinix_metal >= 0.0.1',
-        ]
     )
 
 


### PR DESCRIPTION
This PR removes requirements info from module docs. It's hard to point to the current version in Makefile, and it doesn't really matter per module, and in module docs.