### PR TITLE
Remove "requirements" block from module doc markdown

### DIFF
--- a/plugins/modules/metal_available_ips_info.py
+++ b/plugins/modules/metal_available_ips_info.py
@@ -19,9 +19,7 @@ options:
     - UUID of the reserved IP block to list available IPs for.
     required: true
     type: str
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Get list of avialable IP addresses from a reserved IP block
 '''
 EXAMPLES = '''

--- a/plugins/modules/metal_device.py
+++ b/plugins/modules/metal_device.py
@@ -234,9 +234,7 @@ options:
       for more details.
     required: false
     type: str
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Create, update, or delete Equinix Metal devices
 '''
 EXAMPLES = '''

--- a/plugins/modules/metal_device_info.py
+++ b/plugins/modules/metal_device_info.py
@@ -27,9 +27,7 @@ options:
     - UUID of the project containing devices.
     required: false
     type: str
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Select list of Equinix Metal devices
 ''' 
 EXAMPLES = '''

--- a/plugins/modules/metal_ip_assignment.py
+++ b/plugins/modules/metal_ip_assignment.py
@@ -34,9 +34,7 @@ options:
     - Whether the IP address is manageable.
     required: false
     type: bool
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Manage Equinix Metal IP assignments
 '''
 EXAMPLES = '''

--- a/plugins/modules/metal_ip_assignment_info.py
+++ b/plugins/modules/metal_ip_assignment_info.py
@@ -14,9 +14,7 @@ options:
     - UUID of the device to list ip_assignments for.
     required: true
     type: str
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Gather IP address assignments for a device
 '''
 EXAMPLES = '''

--- a/plugins/modules/metal_project.py
+++ b/plugins/modules/metal_project.py
@@ -45,9 +45,7 @@ options:
     - When blank, the API assumes default org payment method.
     required: false
     type: str
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Manage Projects in Equinix Metal
 '''
 EXAMPLES = '''

--- a/plugins/modules/metal_project_info.py
+++ b/plugins/modules/metal_project_info.py
@@ -22,9 +22,7 @@ options:
     - UUID of the organization containing the project.
     required: false
     type: str
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Gather information about Equinix Metal projects
 '''
 EXAMPLES = '''

--- a/plugins/modules/metal_reserved_ip_block.py
+++ b/plugins/modules/metal_reserved_ip_block.py
@@ -75,9 +75,7 @@ options:
     - The VRF must have an existing IP Range that contains the requested subnet.
     required: false
     type: str
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Create/delete blocks of reserved IP addresses in a project.
 '''
 EXAMPLES = '''

--- a/plugins/modules/metal_reserved_ip_block_info.py
+++ b/plugins/modules/metal_reserved_ip_block_info.py
@@ -33,9 +33,7 @@ options:
     - The type of IP address to list
     required: true
     type: str
-requirements:
-- python >= 3
-- equinix_metal >= 0.0.1
+requirements: null
 short_description: Gather list of reserved IP blocks
 '''
 EXAMPLES = '''


### PR DESCRIPTION
This PR follows #91 and removes the requirements block from the module doc markdown.