### PR TITLE
Make metro for Metal resource integration tests configurable from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ COLLECTION_VERSION ?=
 
 TEST_ARGS := -v
 INTEGRATION_CONFIG := tests/integration/integration_config.yml
+METAL_TEST_METRO ?= sv
 
 clean:
 	rm -f *.tar.gz && rm -rf galaxy.yml
@@ -64,3 +65,4 @@ else
 endif
 	echo "metal_api_token: $(METAL_API_TOKEN)" > $(INTEGRATION_CONFIG)
 	echo "metal_ua_prefix: E2E" >> $(INTEGRATION_CONFIG)
+	echo "metal_test_metro: $(METAL_TEST_METRO)" >> $(INTEGRATION_CONFIG)

--- a/tests/integration/targets/metal_device/tasks/main.yml
+++ b/tests/integration/targets/metal_device/tasks/main.yml
@@ -20,8 +20,6 @@
     - set_fact:
         test_plan: c3.small.x86
     - set_fact:
-        test_metro: da
-    - set_fact:
         wait_seconds: 1200
 
     - name: create project for test
@@ -35,7 +33,7 @@
         hostname: "{{ test_prefix }}-dev1"
         operating_system: "{{ test_os }}"
         plan: "{{ test_plan }}"
-        metro: "{{ test_metro }}"
+        metro: "{{metal_test_metro }}"
         state: present
         provisioning_wait_seconds: "{{ wait_seconds }}"
       register: test_device_1
@@ -58,7 +56,7 @@
         hostname: "{{ test_prefix }}-dev2"
         operating_system: "{{ test_os }}"
         plan: "{{ test_plan }}"
-        metro: "{{ test_metro }}"
+        metro: "{{ metal_test_metro }}"
         state: present
         provisioning_wait_seconds: "{{ wait_seconds }}"
       register: test_device_2

--- a/tests/integration/targets/metal_ip_assignment/tasks/main.yml
+++ b/tests/integration/targets/metal_ip_assignment/tasks/main.yml
@@ -28,8 +28,6 @@
     - set_fact:
         test_plan: c3.small.x86
     - set_fact:
-        test_metro: da
-    - set_fact:
         wait_seconds: 1200
 
     - name: create project for test
@@ -44,7 +42,7 @@
     - name: request ip reservation
       equinix.cloud.metal_reserved_ip_block:
         type: "public_ipv4"
-        metro: "{{ test_metro }}"
+        metro: "{{ metal_test_metro }}"
         quantity: 1
         project_id: "{{ project.id }}"
       register: ip_reservation
@@ -66,7 +64,7 @@
         hostname: "{{ test_prefix }}-dev1"
         operating_system: "{{ test_os }}"
         plan: "{{ test_plan }}"
-        metro: "{{ test_metro }}"
+        metro: "{{ metal_test_metro }}"
         provisioning_wait_seconds: "{{ wait_seconds }}"
         state: present
       register: device

--- a/tests/integration/targets/metal_reserved_ip_block/tasks/main.yml
+++ b/tests/integration/targets/metal_reserved_ip_block/tasks/main.yml
@@ -13,8 +13,6 @@
         unique_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=8') }}"
     - set_fact:
         test_prefix: "{{ test_resource_name_prefix }}-{{ unique_id }}"
-    - set_fact:
-        test_metro: sv
 
     - name: create project for test
       equinix.cloud.metal_project:
@@ -28,7 +26,7 @@
     - name: request ip reservation
       equinix.cloud.metal_reserved_ip_block:
         type: "public_ipv4"
-        metro: "{{ test_metro }}"
+        metro: "{{ metal_test_metro }}"
         quantity: 1
         project_id: "{{ project.id }}"
       register: ip_reservation 
@@ -36,7 +34,7 @@
     - name: idempotence check for ip reservation
       equinix.cloud.metal_reserved_ip_block:
         type: "public_ipv4"
-        metro: "{{ test_metro }}"
+        metro: "{{ metal_test_metro }}"
         quantity: 1
         project_id: "{{ project.id }}"
       register: ip_reservation_idem_check

--- a/tests/integration/targets/metal_reserved_ip_block_info/tasks/main.yml
+++ b/tests/integration/targets/metal_reserved_ip_block_info/tasks/main.yml
@@ -20,8 +20,6 @@
     - set_fact:
         test_prefix: "{{ test_resource_name_prefix }}-{{ unique_id }}"
     - set_fact:
-        test_metro: sv
-    - set_fact:
         test_os: ubuntu_22_04
     - set_fact:
         test_plan: c3.small.x86
@@ -39,7 +37,7 @@
         hostname: "{{ test_prefix }}-dev1"
         operating_system: "{{ test_os }}"
         plan: "{{ test_plan }}"
-        metro: "{{ test_metro }}"
+        metro: "{{ metal_test_metro }}"
         provisioning_wait_seconds: "{{ wait_seconds }}"
         state: present
       register: device
@@ -61,13 +59,13 @@
         that:
         - private_ipv4_reservations.resources|length > 0
         - public_ipv6_reservations.resources|length > 0
-        - private_ipv4_reservations.resources[0].metro == "{{ test_metro }}"
-        - public_ipv6_reservations.resources[0].metro == "{{ test_metro }}"
+        - private_ipv4_reservations.resources[0].metro == "{{ metal_test_metro }}"
+        - public_ipv6_reservations.resources[0].metro == "{{ metal_test_metro }}"
 
     - name: request ip reservation
       equinix.cloud.metal_reserved_ip_block:
         type: "public_ipv4"
-        metro: "{{ test_metro }}"
+        metro: "{{ metal_test_metro }}"
         quantity: 1
         project_id: "{{ project.id }}"
       register: public_ipv4_reservation
@@ -81,7 +79,7 @@
     - assert:
         that:
         - public_ipv4_reservations.resources|length == 1
-        - public_ipv4_reservations.resources[0].metro == "{{ test_metro }}"
+        - public_ipv4_reservations.resources[0].metro == "{{ metal_test_metro }}"
 
   always:
     - name: Announce teardown start


### PR DESCRIPTION
We have Github Action integration tests failing in #92 because of "no capacity in given metro". The metro was harcoded for every test. This way it's configurable from the Makefile and thus easier to change.