### PR TITLE
set pydantic to specific version (1.10.2), to prevent deprication errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 equinix-metal>=0.2.2
 ansible-specdoc>=0.0.13
+pydantic==1.10.2


### PR DESCRIPTION
Equinix_metal library expects pydantic version less than two, as it's using a deprecated object type. Until this is fixed in equinix_metal, we need to set pydantic to a version bellow 2 to prevent deprecation errors.

![image](https://github.com/equinix-labs/ansible-collection-equinix/assets/51121296/8577cdd4-6974-4d3e-9cb4-a74be7ed15e3)
