### PR TITLE
fixes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Releasing
 
-Go to [https://github.com/equinix-labs/ansible-collection-equinix/releases/new](https://github.com/ansible-collection-equinix/metal-python/releases/new) and create a new release from `main`. Don't choose an existing tag. Put version to the field for "Release title", for example `v0.1.2`. Don't add collection number to the Makefile.
+Go to [https://github.com/equinix-labs/ansible-collection-equinix/releases/new](https://github.com/equinix-labs/ansible-collection-equinix/releases/new) and create a new release from `main`. Don't choose an existing tag. Put version to the field for "Release title", for example `v0.1.2`. Don't add collection number to the Makefile.
 
 Add release notes in format of [Terraform Provider Equinix](https://github.com/equinix/terraform-provider-equinix/releases), with at least one of the sections (NOTES, FEATURES, BUG FIXES, ENHANCEMENTS).
 

--- a/README.md
+++ b/README.md
@@ -106,24 +106,7 @@ Use-case examples for this collection can be found [here](./examples).
 
 ## Development
 
-If you want to develop the collecton, it's best to clone it under directory tree `ansible_collections/equinix/cloud`. That way the integration tests can be run without actually installing.
-
-```
-git clone https://github.com/equinix-labs/ansible-collection-equinix devdir/ansible_collections/equinix/cloud
-```
-
-You can try to run integration test for metal_project, that won't incur any fee.
-
-```
-cd devdir/ansible_collections/equinix/cloud
-make test_target=metal_project test
-```
-
-You can then edit existing code, or add new modules or tests.
-
-To install the collection from local directory, do `make install` in the root of the repo.
-
-
+See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Releasing
 

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -89,24 +89,7 @@ Use-case examples for this collection can be found [here](./examples).
 
 ## Development
 
-If you want to develop the collecton, it's best to clone it under directory tree `ansible_collections/equinix/cloud`. That way the integration tests can be run without actually installing.
-
-```
-git clone https://github.com/equinix-labs/ansible-collection-equinix devdir/ansible_collections/equinix/cloud
-```
-
-You can try to run integration test for metal_project, that won't incur any fee.
-
-```
-cd devdir/ansible_collections/equinix/cloud
-make test_target=metal_project test
-```
-
-You can then edit existing code, or add new modules or tests.
-
-To install the collection from local directory, do `make install` in the root of the repo.
-
-
+See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Releasing
 

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -93,7 +93,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Releasing
 
-Go to [https://github.com/equinix-labs/ansible-collection-equinix/releases/new](https://github.com/ansible-collection-equinix/metal-python/releases/new) and create a new release from `main`. Don't choose an existing tag. Put version to the field for "Release title", for example `v0.1.2`. Don't add collection number to the Makefile.
+Go to [https://github.com/equinix-labs/ansible-collection-equinix/releases/new](https://github.com/equinix-labs/ansible-collection-equinix/releases/new) and create a new release from `main`. Don't choose an existing tag. Put version to the field for "Release title", for example `v0.1.2`. Don't add collection number to the Makefile.
 
 Add release notes in format of [Terraform Provider Equinix](https://github.com/equinix/terraform-provider-equinix/releases), with at least one of the sections (NOTES, FEATURES, BUG FIXES, ENHANCEMENTS).
 


### PR DESCRIPTION
This PR 
- fixes main README so that it points to dev doc DEVELOPMENT.md instead of explaining collection development in place.
- fixes link for collection release