### PR TITLE
ignore integration_config.yml for smoother development flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Edit at https://www.gitignore.io/?templates=git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 
 galaxy.yml
+tests/integration/integration_config.yml
 
 ### dotenv ###
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Edit at https://www.gitignore.io/?templates=git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 
 galaxy.yml
+
+### avoid versioning int config where there's python interpreter path ###
 tests/integration/integration_config.yml
 
 ### dotenv ###


### PR DESCRIPTION
When we run tests locally, `tests/integration/integration_config.yml` gets modified (path to python executable I think), and the file gets dirty. We then have to pay attention not to add it to the index and accidentally commit it.

Let's see if the tests run when `tests/integration/integration_config.yml` is in gitignore.