### PR TITLE
docs: Update Galaxy published module URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Equinix Ansible Collection
-[![Ansible Galaxy](https://img.shields.io/badge/galaxy-equinix.cloud-660198.svg?style=flat)](https://galaxy.ansible.com/equinix/cloud/) 
+[![Ansible Galaxy](https://img.shields.io/badge/galaxy-equinix.cloud-660198.svg?style=flat)](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/)
 ![Tests](https://img.shields.io/github/actions/workflow/status/equinix-labs/ansible-collection-equinix/integration-tests.yml?branch=main)
 
 The Ansible Collection Equinix contains various plugins for managing Equinix services.
@@ -141,7 +141,7 @@ The release will create a tag, and we have a Github action in place that should 
 
 Verify that the [releasing Github action](https://github.com/equinix-labs/ansible-collection-equinix/actions) succeeded.
 
-Verify that new version of [equinix.cloud](https://galaxy.ansible.com/equinix/cloud) is available in Ansible Galaxy.
+Verify that new version of [equinix.cloud](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/) is available in Ansible Galaxy.
 
 
 ## Licensing


### PR DESCRIPTION
This https://galaxy.ansible.com/equinix/cloud/ URL is currently 404'ing. This may be a temporary problem.

https://forum.ansible.com/t/403-for-galaxy-api-when-publishing-collection-to-galaxy-ansible-com/1445