### PR TITLE
fix: preserve SDK user agent in collection client

### DIFF
--- a/plugins/module_utils/metal/metal_client.py
+++ b/plugins/module_utils/metal/metal_client.py
@@ -44,13 +44,13 @@ def raise_if_missing_equinix_metal():
 
 def get_equinix_metal_client(api_token, api_url=API_URL, ua_prefix=""):
     raise_if_missing_equinix_metal()
-    ua = ua_prefix + USER_AGENT
+    ua = ua_prefix + " " + USER_AGENT
     conf = equinix_metal.Configuration(
         host=api_url,
     )
     conf.api_key['x_auth_token'] = api_token
     mpc = equinix_metal.ApiClient(conf)
-    mpc.user_agent = ua
+    mpc.user_agent = ua + " " + mpc.user_agent
     return mpc
 
 


### PR DESCRIPTION
fixes #128 

I tested it and now the user agent is `[user_prefix ] ansible-equinix metal-python/0.3.0`