### PR TITLE
feat: bump equinix_metal to v0.4.0

### DIFF
--- a/plugins/module_utils/metal/api_routes.py
+++ b/plugins/module_utils/metal/api_routes.py
@@ -65,18 +65,18 @@ def get_routes(mpc):
 
         # LISTERS
         ('metal_project_device', action.LIST): spec_types.Specs(
-            equinix_metal.DevicesApi(mpc).find_project_devices,
+            equinix_metal.DevicesApi(mpc).find_project_devices_all_pages,
             {'id': 'project_id'},
         ),
         ('metal_organization_device', action.LIST): spec_types.Specs(
-            equinix_metal.DevicesApi(mpc).find_organization_devices,
+            equinix_metal.DevicesApi(mpc).find_organization_devices_all_pages,
             {'id': 'organization_id'},
         ),
         ('metal_project', action.LIST): spec_types.Specs(
-            equinix_metal.ProjectsApi(mpc).find_projects,
+            equinix_metal.ProjectsApi(mpc).find_projects_all_pages,
         ),
         ('metal_organization_project', action.LIST): spec_types.Specs(
-            equinix_metal.OrganizationsApi(mpc).find_organization_projects,
+            equinix_metal.OrganizationsApi(mpc).find_organization_projects_all_pages,
             {'id': 'organization_id'},
         ),
         ('metal_ip_reservation', action.LIST): spec_types.Specs(
@@ -99,7 +99,7 @@ def get_routes(mpc):
             {'id': 'project_id'}
         ),
         ('metal_organization', action.LIST): spec_types.Specs(
-            equinix_metal.OrganizationsApi(mpc).find_organizations,
+            equinix_metal.OrganizationsApi(mpc).find_organizations_all_pages,
             {'personal': 'personal', 'with_projects': 'with_projects'},
         ),
         ('metal_operating_system', action.LIST): spec_types.Specs(
@@ -109,7 +109,7 @@ def get_routes(mpc):
             equinix_metal.MetrosApi(mpc).find_metros,
         ),
         ('metal_project_hardware_reservation', action.LIST): spec_types.Specs(
-            equinix_metal.HardwareReservationsApi(mpc).find_project_hardware_reservations,
+            equinix_metal.HardwareReservationsApi(mpc).find_project_hardware_reservations_all_pages,
             {'id': 'project_id'},
         ),
         ('metal_vlan', action.LIST): spec_types.Specs(
@@ -117,7 +117,7 @@ def get_routes(mpc):
             {'id': 'project_id'},
         ),
         ('metal_connection_project', action.LIST): spec_types.Specs(
-            equinix_metal.InterconnectionsApi(mpc).project_list_interconnections,
+            equinix_metal.InterconnectionsApi(mpc).project_list_interconnections_all_pages,
             {'id': 'project_id'},
         ),
         ('metal_connection_organization', action.LIST): spec_types.Specs(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-equinix-metal==0.3.0
+equinix-metal==0.4.0
 ansible-specdoc>=0.0.13
 pydantic==1.10.5


### PR DESCRIPTION
This PR bumps equinix_metal dep to v0.4.0 where we have proper page walkthrough implemented. In other words, the `_info` modules will get all the existing resources, not only the first page.

I also added a test to check that and `_info` module fetches more than 10 resources (which is the default IIUC).