### PR TITLE
feat: use Python 3.10 in integration tests

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -44,7 +44,7 @@ jobs:
       - name: setup python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: install dependencies
         run: pip3 install -r requirements-dev.txt -r requirements.txt

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: setup python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: install dependencies
         run: python -m pip install -r requirements-dev.txt -r requirements.txt


### PR DESCRIPTION
This PR bumps Python version used in integration tests to 3.10. We might need it if we want to use GHA to publish collection to Galaxy.

Related to #154 