### PR TITLE
ci: Fix docs generation in releasing GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v4
         with:
+          path: .ansible/collections/ansible_collections/equinix/cloud
           fetch-depth: 0
 
       - name: update packages
@@ -31,6 +32,7 @@ jobs:
       - name: Do GitHub release
         uses: cycjimmy/semantic-release-action@v4
         with:
+          working_directory: .ansible/collections/ansible_collections/equinix/cloud
           semantic_version: 19.0.5
           extra_plugins: |
             @semantic-release/exec@6.0.3

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -27,7 +27,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "echo -n '${nextRelease.version}' > version"
+          "prepareCmd": "echo -n '${nextRelease.version}' > version && make docs"
         }
       ],
       [

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -23,7 +23,7 @@ Modules for managing Equinix infrastructure.
 
 Name | Description |
 --- | ------------ |
-{% for mod in modules %}[equinix.cloud.{{ mod.name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
+{% for mod in modules %}[equinix.cloud.{{ mod.name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
 {% endfor %}
 
 ### Info Modules
@@ -32,7 +32,7 @@ Modules for retrieving information about existing Equinix infrastructure.
 
 Name | Description |
 --- | ------------ |
-{% for mod in info_modules %}[equinix.cloud.{{ mod.name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
+{% for mod in info_modules %}[equinix.cloud.{{ mod.name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
 {% endfor %}
 
 ### Inventory Plugins
@@ -41,7 +41,7 @@ Dynamically add Equinix infrastructure to an Ansible inventory.
 
 Name |
 --- |
-{% for name in inventory %}[equinix.cloud.{{ name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/{{ collection_version }}/docs/inventory/{{ name }}.md{% else %}./docs/inventory/{{ name }}.rst{% endif %})|
+{% for name in inventory %}[equinix.cloud.{{ name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/docs/inventory/{{ name }}.md{% else %}./docs/inventory/{{ name }}.rst{% endif %})|
 {% endfor %}
 
 <!--end collection content-->


### PR DESCRIPTION
This PR fixes doc links in readme and plugs doc generation just before GitHub release, so that we have properly-versioned links in main README. Now the doc for metal_device in main-branch README will point to 
https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.3.0/docs/modules/metal_device.md

(when v0.3.0 is the latest release)