### PR TITLE
ci: fix path for GHA blocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .ansible/collections/ansible_collections/equinix/cloud
     steps:
       - name: checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR fixes working directory for Ansible commands in the release GHA

It should fix fail of the release action:
https://github.com/equinix-labs/ansible-collection-equinix/actions/runs/8015714250/job/21896329577#step:6:12