### PR TITLE
ci: add ANSIBLE_ACC_METAL_DEDICATED_CONNECTION_ID to test GHA

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -59,4 +59,5 @@ jobs:
         run: make testall
         env:
           METAL_API_TOKEN: ${{ secrets.METAL_API_TOKEN }}
+          ANSIBLE_ACC_METAL_DEDICATED_CONNECTION_ID: ${{ secrets.ANSIBLE_ACC_METAL_DEDICATED_CONNECTION_ID }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,3 +51,4 @@ jobs:
         run: make testall
         env:
           METAL_API_TOKEN: ${{ secrets.METAL_API_TOKEN }}
+          ANSIBLE_ACC_METAL_DEDICATED_CONNECTION_ID: ${{ secrets.ANSIBLE_ACC_METAL_DEDICATED_CONNECTION_ID }}


### PR DESCRIPTION
This PR adds secret ANSIBLE_ACC_METAL_DEDICATED_CONNECTION_ID to integration test pr as an env var so that we can use it in #141 