### PR TITLE
docs: document return_values specification in specdoc

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -116,7 +116,7 @@ changed: [testhost] => {
 .. define `return_values` in module script (in Python code) as
 
 ```python
-result_sample = [
+return_values = [
   {
     "backend_transfer_enabled": False,
     "changed": True,
@@ -137,7 +137,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_project": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -97,10 +97,54 @@ Our documentation efforts should primarily concentrate on the `SPECDOC_META` var
 
 For examples of SpecField usage in the collection, refer to existing modules. Additionally, the class definition is available in the [ansible-specdoc repository](https://github.com/linode/ansible-specdoc/).
 
-
 SPECDOC_META has other parameters that are quite self-explanatory. Just note that the `examples` value, and the `sample` for SpecRetrunValue should both be lists.
 
-The `return_values` dictionary does not itemize every key of the module output. Instead, it includes a dictionary with the module name, and a `sample` subkey is populated with example module output. Importantly, the value of the `sample` should be in list format.
+The `return_values` should be formatted as a list of dictionaries. If the output of module called `metal_project` is
+```json
+changed: [testhost] => {
+    "backend_transfer_enabled": false,
+    "changed": true,
+    "customdata": {},
+    "description": "",
+    "id": "e4a49767-824d-4b60-a55e-d66f4baaf7ea",
+    "invocation": {},
+    "name": "ansible-integration-test-project-j9sa85k8-project2",
+    "organization_id": "4d12f460-8c5e-43ea-986d-529d328815ee",
+    "payment_method_id": ""
+}
+```
+.. define `return_values` in module script (in Python code) as
+
+```python
+result_sample = [
+  {
+    "backend_transfer_enabled": False,
+    "changed": True,
+    "customdata": {},
+    "description": "",
+    "id": "e4a49767-824d-4b60-a55e-d66f4baaf7ea",
+    "name": "ansible-integration-test-project-csle6t2y-project1_renamed",
+    "organization_id": "70c2f878-9f32-452e-8c69-ab15480e1d99",
+    "payment_method_id": "845b45a3-c565-47e5-b9b6-a86204a73d29"
+  },
+]
+
+# .. and in SPECDOC_META:
+
+SPECDOC_META = getSpecDocMeta(
+    # ...
+    return_values={
+        "metal_project": SpecReturnValue(
+            description='The module object',
+            type=FieldType.dict,
+            sample=result_sample,
+        ),
+    },
+)
+```
+
+All the samples will be rendered in markdown docs visible in the GitHub repo, only the first sample will be rendered in ansible-doc visible in Ansible Galaxy.
+
 
 ###  2.3. <a name='mainfunction'></a>main() function
 

--- a/plugins/modules/metal_available_ips_info.py
+++ b/plugins/modules/metal_available_ips_info.py
@@ -75,7 +75,7 @@ equinix.cloud.metal_available_ips_info:
 ''',
 ]
 
-result_sample = [
+return_values = [
 {
     "available": [
         "147.75.71.192/32"
@@ -92,7 +92,7 @@ SPECDOC_META = getSpecDocMeta(
         "available": SpecReturnValue(
             description='Available IP addresses from the reservation.',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_bgp_session.py
+++ b/plugins/modules/metal_bgp_session.py
@@ -125,7 +125,7 @@ specdoc_examples = ['''
 ''',
 ]
 
-result_sample = [
+return_values = [
         {
             "address_family": "ipv4",
             "default_route": True,
@@ -156,7 +156,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_bgp_session": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_bgp_session_info.py
+++ b/plugins/modules/metal_bgp_session_info.py
@@ -77,7 +77,7 @@ specdoc_examples = ['''
 ''',
                     ]
 
-result_sample = [
+return_values = [
   {
     "address_family": "ipv6",
     "default_route": True,
@@ -97,7 +97,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_connection.py
+++ b/plugins/modules/metal_connection.py
@@ -293,7 +293,7 @@ specdoc_examples = [
 """,
 ]
 
-result_sample = [
+return_values = [
   {
     "project_id": "Bhf47603-7a09-4ca1-af67-4087c13ab5b6",
     "name": "new connection",
@@ -319,7 +319,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_resource": SpecReturnValue(
             description="The module object",
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_connection_info.py
+++ b/plugins/modules/metal_connection_info.py
@@ -88,7 +88,7 @@ specdoc_examples = [
 """
 ]
 
-result_sample = [
+return_values = [
   {
     "id": "31d3ae8b-bd5a-41f3-a420-055211345cc7",
     "name": "my_test_connection",
@@ -109,7 +109,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description="Found resources",
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_device.py
+++ b/plugins/modules/metal_device.py
@@ -552,7 +552,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
 {
     "always_pxe": False,
     "billing_cycle": "hourly",
@@ -644,7 +644,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_device": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_device_info.py
+++ b/plugins/modules/metal_device_info.py
@@ -210,7 +210,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
         "always_pxe": False,
         "billing_cycle": "hourly",
@@ -380,7 +380,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description="List of devices",
             type=FieldType.list,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_gateway.py
+++ b/plugins/modules/metal_gateway.py
@@ -194,7 +194,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
 {
                  
   "changed": True,
@@ -232,7 +232,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_gateway": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_gateway_info.py
+++ b/plugins/modules/metal_gateway_info.py
@@ -74,7 +74,7 @@ specdoc_examples = ['''
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
         "id": "771c9418-7c60-4a45-8fa6-3a002132331d",
         "ip_reservation_id": "d45c9629-3aab-4a7b-af5d-4ca50041e311",
@@ -104,7 +104,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found Metal Gateways',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_hardware_reservation.py
+++ b/plugins/modules/metal_hardware_reservation.py
@@ -130,7 +130,7 @@ specdoc_examples = [
 '''
 ]
 
-result_sample = [
+return_values = [
 {
     "changed": False,
     "device_id": "",
@@ -156,7 +156,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_hardware_reservation": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_hardware_reservation_info.py
+++ b/plugins/modules/metal_hardware_reservation_info.py
@@ -71,7 +71,7 @@ specdoc_examples = ['''
 ''',
                     ]
 
-result_sample = [
+return_values = [
     {
         "device_id": "",
         "id": "84363c08-a7f5-4e09-8b34-634e82e527c1",
@@ -94,7 +94,7 @@ SPECDOC_META = getSpecDocMeta(
         "hardware_reservations": SpecReturnValue(
             description='Found hardware reservations',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_ip_assignment.py
+++ b/plugins/modules/metal_ip_assignment.py
@@ -164,7 +164,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
 {
     "address": "147.75.71.192/32",
     "address_family": 4,
@@ -193,7 +193,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_ip_assignment": SpecReturnValue(
             description='The assignment object.',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_ip_assignment_info.py
+++ b/plugins/modules/metal_ip_assignment_info.py
@@ -100,7 +100,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
         "address": "147.75.55.115/31",
         "address_family": 4,
@@ -158,7 +158,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_metro_info.py
+++ b/plugins/modules/metal_metro_info.py
@@ -78,7 +78,7 @@ specdoc_examples = ['''
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
         "code": "sv",
         "country": "US",
@@ -116,7 +116,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found metros',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_operating_system_info.py
+++ b/plugins/modules/metal_operating_system_info.py
@@ -93,7 +93,7 @@ specdoc_examples = ['''
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
         "distro": "windows",
         "distro_label": "Windows",
@@ -147,7 +147,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found Operating Systems',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_organization.py
+++ b/plugins/modules/metal_organization.py
@@ -91,7 +91,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
 
     "changed": False,
@@ -123,7 +123,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_organization": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_organization_info.py
+++ b/plugins/modules/metal_organization_info.py
@@ -105,7 +105,7 @@ specdoc_examples = ['''
 ''',
                     ]
 
-result_sample = [
+return_values = [
     {
         "description": "",
         "id": "72342434-9423-454e-8423-ab6546461d99",
@@ -129,7 +129,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found organizations',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_plan_info.py
+++ b/plugins/modules/metal_plan_info.py
@@ -127,7 +127,7 @@ specdoc_examples = ['''
 ''',
 ]
 
-result_sample = [
+return_values = [
   {
     "available_in": [],
     "available_in_metros": [],
@@ -159,7 +159,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_project.py
+++ b/plugins/modules/metal_project.py
@@ -177,7 +177,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
 {
   "backend_transfer_enabled": False,
   "changed": False,
@@ -207,7 +207,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_project": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_project_bgp_config.py
+++ b/plugins/modules/metal_project_bgp_config.py
@@ -128,7 +128,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
         "changed": True
     }
@@ -149,7 +149,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_project_bgp_config": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_project_info.py
+++ b/plugins/modules/metal_project_info.py
@@ -87,7 +87,7 @@ specdoc_examples = ['''
 ''',
                     ]
 
-result_sample = [
+return_values = [
   {
     "backend_transfer_enabled": False,
     "customdata": {},
@@ -110,7 +110,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_project_ssh_key.py
+++ b/plugins/modules/metal_project_ssh_key.py
@@ -131,7 +131,7 @@ specdoc_examples = [
 """,
 ]
 
-result_sample = [
+return_values = [
     {
     "fingerprint": "98:9c:35:ed:f9:75:5b:52:e2:70:50:22:ea:77:5b:b6",
     "id": "eef49903-7a09-4ca1-af67-4087c29ab5b6",
@@ -157,7 +157,7 @@ SPECDOC_META = getSpecDocMeta(
         MODULE_NAME: SpecReturnValue(
             description="The module object",
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_project_ssh_key_info.py
+++ b/plugins/modules/metal_project_ssh_key_info.py
@@ -96,7 +96,7 @@ specdoc_examples = [
 """,
 ]
 
-result_sample = [
+return_values = [
     {
         "fingerprint": "70:c1:73:8b:3f:2f:a4:18:ea:4d:79:13:52:7b:c4:3e",
         "id": "6edfcbc2-17e5-4221-9eac-2f40dbe60daf",
@@ -124,7 +124,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description="Found resources",
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_reserved_ip_block.py
+++ b/plugins/modules/metal_reserved_ip_block.py
@@ -161,7 +161,7 @@ specdoc_examples = [
 ]
 
 
-result_sample = [
+return_values = [
     {
         "address_family": 4,
         "changed": True,
@@ -252,7 +252,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_reserved_ip_block": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_reserved_ip_block_info.py
+++ b/plugins/modules/metal_reserved_ip_block_info.py
@@ -117,7 +117,7 @@ module_spec = dict(
     ),
 )
 
-result_sample = [
+return_values = [
     {
         "address_family": 4,
         "customdata": {},
@@ -144,7 +144,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_ssh_key.py
+++ b/plugins/modules/metal_ssh_key.py
@@ -114,7 +114,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
     "fingerprint": "98:9c:35:ed:f9:75:5b:52:e2:70:50:22:ea:77:5b:b6",
     "id": "260c8ef0-2667-4446-9c9d-a156f7234da6",
@@ -141,7 +141,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_ssh_key": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_ssh_key_info.py
+++ b/plugins/modules/metal_ssh_key_info.py
@@ -80,7 +80,7 @@ specdoc_examples = [
 ]
 
 
-result_sample = [
+return_values = [
     {
         "fingerprint": "70:c1:73:8b:3f:2f:a4:18:ea:4d:79:13:52:7b:c4:3e",
         "id": "6edfcbc2-17e5-4221-9eac-2f40dbe60daf",
@@ -105,7 +105,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_vlan.py
+++ b/plugins/modules/metal_vlan.py
@@ -126,7 +126,7 @@ specdoc_examples = [
 """,
 ]
 
-result_sample = [
+return_values = [
     {
     "changed": False,
     "id": "7624f0f7-75b6-4271-bc64-632b80f87de2",
@@ -152,7 +152,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_vlan": SpecReturnValue(
             description="The module object",
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_vlan_info.py
+++ b/plugins/modules/metal_vlan_info.py
@@ -63,7 +63,7 @@ specdoc_examples = ['''
 ''',
 ]
 
-result_sample = [
+return_values = [
   {
     "vxlan": 1234,
     "metro": "se",
@@ -83,7 +83,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_vrf.py
+++ b/plugins/modules/metal_vrf.py
@@ -166,7 +166,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = [
+return_values = [
     {
         "changed": False,
         "description": "Test VRF with ASN 65000",
@@ -200,7 +200,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_vrf": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/plugins/modules/metal_vrf_info.py
+++ b/plugins/modules/metal_vrf_info.py
@@ -96,7 +96,7 @@ specdoc_examples = ['''
 ''',
                     ]
 
-result_sample = [
+return_values = [
     {
         "description": "Test VRF with ASN 65000",
         "id": "8b24de5b-c70e-4a4e-9dd2-064ceb09c587",
@@ -125,7 +125,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/template/metal_resource.py
+++ b/template/metal_resource.py
@@ -62,7 +62,7 @@ specdoc_examples = [
 ''',
 ]
 
-result_sample = ['''
+return_values = ['''
 {
   "changed": false,
   "id": "7624f0f7-75b6-4271-bc64-632b80f87de2",
@@ -88,7 +88,7 @@ SPECDOC_META = getSpecDocMeta(
         "metal_resource": SpecReturnValue(
             description='The module object',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )

--- a/template/metal_resource_info.py
+++ b/template/metal_resource_info.py
@@ -42,7 +42,7 @@ specdoc_examples = ['''
 ''',
                     ]
 
-result_sample = ['''
+return_values = ['''
 
 [  
   {
@@ -64,7 +64,7 @@ SPECDOC_META = getSpecDocMeta(
         "resources": SpecReturnValue(
             description='Found resources',
             type=FieldType.dict,
-            sample=result_sample,
+            sample=return_values,
         ),
     },
 )


### PR DESCRIPTION
This PR adds development docs on how to specify return value example of a module. We had to fix this because of ansible-specdoc and ansible-doc, and @ctreatma asked for the return value spec to be documented.

Rendered it looks like this:
https://github.com/equinix-labs/ansible-collection-equinix/blob/document_return_value_docs_specification/DEVELOPMENT.md#22-documentation-and-the-specdoc-fields