### PR TITLE
ci: add pr-triggered GHA to validate ansible-specdoc documentation

### DIFF
--- a/.github/workflows/docs-generation-test-pr.yml
+++ b/.github/workflows/docs-generation-test-pr.yml
@@ -1,0 +1,43 @@
+on: 
+  pull_request_target:
+    paths:
+    - plugins/**
+    - Makefile
+    - requirements.txt
+    - requirements-dev.txt
+    - .github/**
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  integration-test-pr:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .ansible/collections/ansible_collections/equinix/cloud
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: .ansible/collections/ansible_collections/equinix/cloud            
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: update packages
+        run: sudo apt-get update -y
+
+      - name: install make
+        run: sudo apt-get install -y build-essential
+
+      - name: setup python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: install dependencies
+        run: pip3 install -r requirements-dev.txt -r requirements.txt
+
+      - name: run docs generation
+        run: make docs
+

--- a/.github/workflows/docs-generation-test-pr.yml
+++ b/.github/workflows/docs-generation-test-pr.yml
@@ -1,5 +1,5 @@
 on: 
-  pull_request_target:
+  pull_request:
     paths:
     - plugins/**
     - Makefile


### PR DESCRIPTION
This PR adds GHA that will run `make docs`. If that succeeds, it's guaranteed that docs are properly generated and that the format is OK for ansible-doc, which should render well in ansible-galaxy.

It's triggered in PRs or manually, auth token not needed so also no authorization.

I think we need to merge this to test properly.