### PR TITLE
docs: fix link to dynamic inventory docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Dynamically add Equinix infrastructure to an Ansible inventory.
 
 Name |
 --- |
-[equinix.cloud.metal_device](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.6.0/docs/inventory/metal_device.md)|
+[equinix.cloud.metal_device](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.6.0/docs/inventory/metal_device.rst)|
 
 
 <!--end collection content-->

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -41,7 +41,7 @@ Dynamically add Equinix infrastructure to an Ansible inventory.
 
 Name |
 --- |
-{% for name in inventory %}[equinix.cloud.{{ name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/docs/inventory/{{ name }}.md{% else %}./docs/inventory/{{ name }}.rst{% endif %})|
+{% for name in inventory %}[equinix.cloud.{{ name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/docs/inventory/{{ name }}.rst{% else %}./docs/inventory/{{ name }}.rst{% endif %})|
 {% endfor %}
 
 <!--end collection content-->


### PR DESCRIPTION
This PR fixes link to dynamic inventory docs in README