### PR TITLE
docs: fix device info docs to point at equinix.cloud

### DIFF
--- a/docs/modules/metal_device_info.md
+++ b/docs/modules/metal_device_info.md
@@ -13,7 +13,7 @@ Select list of Equinix Metal devices
 - name: Gather information about all devices
   hosts: localhost
   tasks:
-      - equinix.metal.device_info:
+      - equinix.cloud.metal_device_info:
 
 ```
 
@@ -21,7 +21,7 @@ Select list of Equinix Metal devices
 - name: Gather information about devices in a particular project using ID
   hosts: localhost
   tasks:
-      - equinix.metal.device_info:
+      - equinix.cloud.metal_device_info:
             project_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
 
 ```
@@ -30,7 +30,7 @@ Select list of Equinix Metal devices
 - name: Gather information about devices in a particular organization using ID
   hosts: localhost
   tasks:
-      - equinix.metal.device_info:
+      - equinix.cloud.metal_device_info:
             organization_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
 
 ```
@@ -39,7 +39,7 @@ Select list of Equinix Metal devices
 - name: Gather information about devices with "webserver" in hostname in a project
   hosts: localhost
   tasks:
-      - equinix.metal.device_info:
+      - equinix.cloud.metal_device_info:
             project_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
             hostname: webserver
 

--- a/plugins/modules/metal_device_info.py
+++ b/plugins/modules/metal_device_info.py
@@ -34,21 +34,21 @@ EXAMPLES = '''
 - name: Gather information about all devices
   hosts: localhost
   tasks:
-  - equinix.metal.device_info: null
+  - equinix.cloud.metal_device_info: null
 - name: Gather information about devices in a particular project using ID
   hosts: localhost
   tasks:
-  - equinix.metal.device_info:
+  - equinix.cloud.metal_device_info:
       project_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
 - name: Gather information about devices in a particular organization using ID
   hosts: localhost
   tasks:
-  - equinix.metal.device_info:
+  - equinix.cloud.metal_device_info:
       organization_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
 - name: Gather information about devices with "webserver" in hostname in a project
   hosts: localhost
   tasks:
-  - equinix.metal.device_info:
+  - equinix.cloud.metal_device_info:
       project_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
       hostname: webserver
 '''
@@ -187,24 +187,24 @@ specdoc_examples = [
 - name: Gather information about all devices
   hosts: localhost
   tasks:
-      - equinix.metal.device_info:
+      - equinix.cloud.metal_device_info:
 ''', '''
 - name: Gather information about devices in a particular project using ID
   hosts: localhost
   tasks:
-      - equinix.metal.device_info:
+      - equinix.cloud.metal_device_info:
             project_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
 ''', '''
 - name: Gather information about devices in a particular organization using ID
   hosts: localhost
   tasks:
-      - equinix.metal.device_info:
+      - equinix.cloud.metal_device_info:
             organization_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
 ''', '''
 - name: Gather information about devices with "webserver" in hostname in a project
   hosts: localhost
   tasks:
-      - equinix.metal.device_info:
+      - equinix.cloud.metal_device_info:
             project_id: 173d7f11-f7b9-433e-ac40-f1571a38037a
             hostname: webserver
 ''',


### PR DESCRIPTION
Found references in the docs pertaining to device_info that were using the old module and thus didn't work, so updating the references to point to the current module.