### PR TITLE
fix: skip uuid check when hardware_reservation_id is next-available

### DIFF
--- a/plugins/module_utils/equinix.py
+++ b/plugins/module_utils/equinix.py
@@ -106,6 +106,9 @@ class EquinixModule(AnsibleModule):
             uuid_args = {k: v for k, v in self.params.items() if (k == "id") | (k.endswith("_id"))}
             for k, v in uuid_args.items():
                 if v is not None:
+                    # Skip uuid check for next-available when using reserved hardware
+                    if k == "hardware_reservation_id" and v == "next-available":
+                        continue
                     if not metal_client.is_valid_uuid(v):
                         raise Exception("Invalid UUID for {0}: {1}".format(k, v))
         except Exception as e:


### PR DESCRIPTION
When using reserved hardware the api https://github.com/equinix-labs/ansible-collection-equinix/blob/55bc3d1b645a859b7b3c93309cf5b264d23a4976/plugins/modules/metal_device.py#L373 says you can provide `next-available` instead of the device uuid, but currently this is still checked against the uuid  regex and the exception is thrown https://github.com/equinix-labs/ansible-collection-equinix/blob/55bc3d1b645a859b7b3c93309cf5b264d23a4976/plugins/module_utils/equinix.py#L110 

Skipping the uuid check if this is the case.