### PR TITLE
fix: upgrade metal-python to remove validation errors for Metal plans

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-equinix-metal==0.9.0
+equinix-metal==0.10.1
 ansible-specdoc>=0.0.13
 pydantic >= 2
 requests


### PR DESCRIPTION
Fixes #188 