### PR TITLE
feat: metal_vlan to allow metal api to automatically pick vlan id

### DIFF
--- a/docs/modules/metal_vlan.md
+++ b/docs/modules/metal_vlan.md
@@ -1,6 +1,6 @@
 # metal_vlan
 
-Manage the VLAN in Equinix Metal. You can use *id* or *vxlan* to lookup the resource. If you want to create new resource, you must provide *metro*.
+Manage the VLAN in Equinix Metal. You can use *id*, *vxlan* or *tags* to lookup the resource. If you want to create new resource, you must provide *metro*.
 
 
 - [Examples](#examples)
@@ -18,6 +18,7 @@ Manage the VLAN in Equinix Metal. You can use *id* or *vxlan* to lookup the reso
       metro: "se"
       vxlan: 1234
       project_id: "778h50f7-75b6-4271-bc64-632b80f87de2"
+      tags: ["my_vlan", "se"]
 
 ```
 
@@ -39,6 +40,8 @@ Manage the VLAN in Equinix Metal. You can use *id* or *vxlan* to lookup the reso
 | `description` | <center>`str`</center> | <center>Optional</center> | Description of the VLAN   |
 | `metro` | <center>`str`</center> | <center>Optional</center> | Metro in which to create the VLAN   |
 | `vxlan` | <center>`int`</center> | <center>Optional</center> | VLAN ID, must be unique in metro   |
+| `tags` | <center>`list`</center> | <center>Optional</center> | Resource tags   |
+
 
 
 
@@ -57,6 +60,7 @@ Manage the VLAN in Equinix Metal. You can use *id* or *vxlan* to lookup the reso
   "id": "7624f0f7-75b6-4271-bc64-632b80f87de2",
   "metro": "se",
   "project_id": "778h50f7-75b6-4271-bc64-632b80f87de2",
+  "tags": ["my_vlan", "se"],
   "vxlan": 1234
 }
 ```

--- a/plugins/module_utils/equinix.py
+++ b/plugins/module_utils/equinix.py
@@ -139,7 +139,7 @@ class EquinixModule(AnsibleModule):
 
     def get_one_with_tags(self, resource_type: str, tags: List[str]):
         '''
-        Gets exactly one resource matching a list og tags.
+        Gets exactly one resource matching a list of tags.
 
         This function runs a list call for the resource_type specified, and
         returns zero or one elements matching a set of tags. Raises an exception
@@ -154,7 +154,7 @@ class EquinixModule(AnsibleModule):
             resource_tags = i.get("tags")
             # if break statement isn't hit, `else` block runs.
             for t in tags:
-                if t not in tags:
+                if t not in resource_tags:
                     break
             else:
                 matches.append(i)
@@ -162,7 +162,7 @@ class EquinixModule(AnsibleModule):
         if len(matches) == 0:
             return None
         if len(matches) > 1:
-            raise Exception(f'found more than one {resource_type} with tags {tags}')
+            raise Exception(f'found more than one {resource_type} with tags {tags}: {matches}')
         return matches[0]
 
     def get_one_from_list(self, resource_type: str, match_attrs: List[str]):

--- a/plugins/module_utils/equinix.py
+++ b/plugins/module_utils/equinix.py
@@ -137,6 +137,34 @@ class EquinixModule(AnsibleModule):
             raise e
         return result
 
+    def get_one_with_tags(self, resource_type: str, tags: List[str]):
+        '''
+        Gets exactly one resource matching a list og tags.
+
+        This function runs a list call for the resource_type specified, and
+        returns zero or one elements matching a set of tags. Raises an exception
+        if more than one resource matches.
+        '''
+        if self.params.get('tags') is None:
+            raise Exception("get_with_tags called without tags, this is a module bug.")   
+
+        result = self._metal_api_call(resource_type, action.LIST, self.params.copy())
+        matches = []
+        for i in result:
+            resource_tags = i.get("tags")
+            # if break statement isn't hit, `else` block runs.
+            for t in tags:
+                if t not in tags:
+                    break
+            else:
+                matches.append(i)
+
+        if len(matches) == 0:
+            return None
+        if len(matches) > 1:
+            raise Exception(f'found more than one {resource_type} with tags {tags}')
+        return matches[0]
+
     def get_one_from_list(self, resource_type: str, match_attrs: List[str]):
         match_values = []
         for attr in match_attrs:

--- a/plugins/module_utils/metal/metal_api.py
+++ b/plugins/module_utils/metal/metal_api.py
@@ -233,6 +233,7 @@ VLAN_RESPONSE_ATTRIBUTE_MAP = {
     "description": optional_str('description'),
     "metro": "metro",
     "vxlan": "vxlan",
+    "tags": "tags",
 }
 
 METAL_CONNECTION_RESPONSE_ATTRIBUTE_MAP = {

--- a/plugins/modules/metal_vlan.py
+++ b/plugins/modules/metal_vlan.py
@@ -8,7 +8,7 @@
 
 DOCUMENTATION = '''
 author: Equinix DevRel Team (@equinix) <support@equinix.com>
-description: Manage the VLAN in Equinix Metal. You can use *id* or *vxlan* to lookup
+description: Manage the VLAN in Equinix Metal. You can use *id*, *vxlan* or *tags* to lookup
   the resource. If you want to create new resource, you must provide *metro*.
 module: metal_vlan
 notes: []
@@ -38,6 +38,11 @@ options:
     - VLAN ID, must be unique in metro
     required: false
     type: int
+  tags:
+    description:
+    - Resource tags
+    required: false
+    type: list
 requirements: null
 short_description: Manage a VLAN resource in Equinix Metal
 '''
@@ -50,6 +55,9 @@ EXAMPLES = '''
       metro: se
       vxlan: 1234
       project_id: 778h50f7-75b6-4271-bc64-632b80f87de2
+      tags:
+        - "my_vlan"
+        - "se"
 '''
 RETURN = '''
 metal_vlan:
@@ -62,6 +70,9 @@ metal_vlan:
     metro: se
     project_id: 778h50f7-75b6-4271-bc64-632b80f87de2
     vxlan: 1234
+    tags: 
+        - "my_vlan"
+        - "se"
   type: dict
 '''
 
@@ -113,7 +124,7 @@ module_spec = dict(
     tags=SpecField(
         type=FieldType.list,
         element_type=FieldType.string,
-        description=["List of tags to match. Matches only resources that have all the tags provided."],
+        description=["Resource tags"],
     ),
 )
 
@@ -128,7 +139,9 @@ specdoc_examples = [
       metro: "se"
       vxlan: 1234
       project_id: "778h50f7-75b6-4271-bc64-632b80f87de2"
-      tags: ["my_vlan", "se"]
+      tags:
+        - "my_vlan"
+        - "se"
 """,
 ]
 

--- a/plugins/modules/metal_vlan.py
+++ b/plugins/modules/metal_vlan.py
@@ -110,6 +110,11 @@ module_spec = dict(
         type=FieldType.integer,
         description=["VLAN ID, must be unique in metro"],
     ),
+    tags=SpecField(
+        type=FieldType.list,
+        element_type=FieldType.string,
+        description=["List of tags to match. Matches only resources that have all the tags provided."],
+    ),
 )
 
 
@@ -123,6 +128,7 @@ specdoc_examples = [
       metro: "se"
       vxlan: 1234
       project_id: "778h50f7-75b6-4271-bc64-632b80f87de2"
+      tags: ["my_vlan", "se"]
 """,
 ]
 
@@ -133,7 +139,8 @@ return_values = [
     "description": "This is my new VLAN.",
     "metro": "se",
     "vxlan": 1234,
-    "project_id": "778h50f7-75b6-4271-bc64-632b80f87de2"
+    "project_id": "778h50f7-75b6-4271-bc64-632b80f87de2",
+    "tags": ["my_vlan", "se"]
     }
 ]
 
@@ -143,7 +150,7 @@ SPECDOC_META = getSpecDocMeta(
     short_description="Manage a VLAN resource in Equinix Metal",
     description=(
         "Manage the VLAN in Equinix Metal. "
-        "You can use *id* or *vxlan* to lookup the resource. "
+        "You can use *id*, *vxlan* or *tags* to lookup the resource. "
         "If you want to create new resource, you must provide *metro*."
     ),
     examples=specdoc_examples,
@@ -167,9 +174,13 @@ def main():
     changed = False
     try:
         module.params_syntax_check()
+
+        # if `id` is not specified, then we try to match either `tags` or `vxlan` id to find an existing resource. 
         if module.params.get("id"):
             tolerate_not_found = state == "absent"
             fetched = module.get_by_id(MODULE_NAME, tolerate_not_found)
+        elif module.params.get("tags"):
+            fetched = module.get_one_with_tags(MODULE_NAME, module.params.get("tags"))
         else:
             fetched = module.get_one_from_list(
                 MODULE_NAME,

--- a/tests/integration/targets/metal_vlan/tasks/main.yml
+++ b/tests/integration/targets/metal_vlan/tasks/main.yml
@@ -22,6 +22,8 @@
         test_description: 'My new VLAN'
     - set_fact:
         test_vxlan: 123
+    - set_fact:
+        vlan_tags: ["a", "b", "c", "d"]
 
     - name: create project for test
       equinix.cloud.metal_project:
@@ -63,6 +65,39 @@
     - name: delete vlan again to check indempotence
       equinix.cloud.metal_vlan:
         id: "{{ first_vlan.id }}"
+        state: absent
+
+    - name: create vlan with tags
+      equinix.cloud.metal_vlan:
+        project_id: "{{ project.id }}"
+        metro: "{{ test_metro }}"
+        description: "{{ test_description }}"
+        tags: "{{ vlan_tags }}"
+      register: second_vlan
+
+    - assert:
+        that:
+          - second_vlan.vxlan != 0
+          - second_vlan.tags | length != 0
+
+    - name: fetch existing vlan..with tags
+      equinix.cloud.metal_vlan:
+        tags: "{{ vlan_tags }}"
+      register: second_vlan_fetched
+
+    - assert:
+        that:
+          - second_vlan_fetched.vxlan ==  second_vlan.vxlan
+          - second_vlan_fetched.tags | length == second_vlan.tags | length
+
+    - name: delete vlan
+      equinix.cloud.metal_vlan:
+        id: "{{ second_vlan.id }}"
+        state: absent
+
+    - name: delete vlan again to check indempotence
+      equinix.cloud.metal_vlan:
+        id: "{{ second_vlan.id }}"
         state: absent
 
   always:

--- a/tests/integration/targets/metal_vlan/tasks/main.yml
+++ b/tests/integration/targets/metal_vlan/tasks/main.yml
@@ -80,24 +80,28 @@
           - second_vlan.vxlan != 0
           - second_vlan.tags | length != 0
 
-    - name: fetch existing vlan..with tags
+    - name: fetch existing vlan with tags
       equinix.cloud.metal_vlan:
+        project_id: "{{ project.id }}"
         tags: "{{ vlan_tags }}"
       register: second_vlan_fetched
 
     - assert:
         that:
+          - second_vlan_fetched.id ==  second_vlan.id
           - second_vlan_fetched.vxlan ==  second_vlan.vxlan
           - second_vlan_fetched.tags | length == second_vlan.tags | length
 
-    - name: delete vlan
+    - name: delete vlan with tags
       equinix.cloud.metal_vlan:
-        id: "{{ second_vlan.id }}"
+        project_id: "{{ project.id }}"
+        tags: "{{ vlan_tags }}"
         state: absent
 
-    - name: delete vlan again to check indempotence
+    - name: delete vlan with tags again to check indempotence
       equinix.cloud.metal_vlan:
-        id: "{{ second_vlan.id }}"
+        project_id: "{{ project.id }}"
+        tags: "{{ vlan_tags }}"
         state: absent
 
   always:


### PR DESCRIPTION
right now, passing the vxlan id is mandatory if one wants to create a new metal_vlan. with this patch, we allow omitting the vxlan id (while passing a set of tags), and metal api picks one available id for us. useful when we don't want to worry about managing ids. if the same call with the same tags are passed, the module should find the resource that was previously created with the same set of tags.


reference: https://developer.equinix.com/catalog/metalv1#operation/createVirtualNetwork