### PR TITLE
feat: metal_vlan_info supports facility based vlans

### DIFF
--- a/plugins/module_utils/metal/metal_api.py
+++ b/plugins/module_utils/metal/metal_api.py
@@ -231,7 +231,8 @@ METAL_METRO_RESPONSE_ATTRIBUTE_MAP = {
 VLAN_RESPONSE_ATTRIBUTE_MAP = {
     "id": "id",
     "description": optional_str('description'),
-    "metro": "metro",
+    "metro": optional_str("metro"),
+    "facility": optional_str("facility"),
     "vxlan": "vxlan",
     "tags": "tags",
 }

--- a/plugins/module_utils/metal/metal_api.py
+++ b/plugins/module_utils/metal/metal_api.py
@@ -231,8 +231,8 @@ METAL_METRO_RESPONSE_ATTRIBUTE_MAP = {
 VLAN_RESPONSE_ATTRIBUTE_MAP = {
     "id": "id",
     "description": optional_str('description'),
-    "metro": optional_str("metro"),
-    "facility": optional_str("facility"),
+    "metro": optional("metro"),
+    "facility": optional("facility"),
     "vxlan": "vxlan",
     "tags": "tags",
 }


### PR DESCRIPTION
vlans can be facility based, but the current metal_vlan_info code doesn't handle that case - it fails since a facility based vlan doesn't have the metro field, which is treated as required by the VLAN_RESPONSE_ATTRIBUTE_MAP.
this PR changes the metro attribute to be optional, and adds a new optional attribute for the facility, so it can handle both cases

```
        {
            "description": "native vlan",
            "facility": { <<<
                "href": "/metal/v1/facilities/d2a72094-26c9-4372-8d65-051424bc370a",
                "id": "d2a72094-26c9-4372-8d65-051424bc370a"
            },
            "id": "abcd",
            "metro": "",
            "vxlan": 1004
        },
        {
            "description": "Public NAT",
            "facility": "",
            "id": "abcd",
            "metro": { <<<
                "href": "/metal/v1/locations/metros/d3d6b29f-042d-43b7-b3ce-0bf53d5754ca",
                "id": "d3d6b29f-042d-43b7-b3ce-0bf53d5754ca"
            },
            "vxlan": 1004
        },
```
addresses #195 