### PR TITLE
feat: metal_vlan to return metal_gateway field from api response

### DIFF
--- a/plugins/module_utils/metal/metal_api.py
+++ b/plugins/module_utils/metal/metal_api.py
@@ -235,6 +235,7 @@ VLAN_RESPONSE_ATTRIBUTE_MAP = {
     "facility": optional("facility"),
     "vxlan": "vxlan",
     "tags": "tags",
+    "metal_gateways": "metal_gateways",
 }
 
 METAL_CONNECTION_RESPONSE_ATTRIBUTE_MAP = {

--- a/tests/integration/targets/metal_gateway/tasks/main.yml
+++ b/tests/integration/targets/metal_gateway/tasks/main.yml
@@ -68,6 +68,15 @@
         that:
           - "listed_gateways.resources | length == 2"
 
+    - name: get vlan for test
+      equinix.cloud.metal_vlan:
+        id: "{{ vlan.id }}"
+      register: vlan
+
+    - assert:
+        that:
+          - "vlan.metal_gateways | length == 2"
+
     - name: delete gateways
       equinix.cloud.metal_gateway:
         id: "{{ item.id }}"


### PR DESCRIPTION
it might be useful to know the metal gateways on a vlan, so it makes sense to expose it in this module