### PR TITLE
feat: update docs to reference new repo location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The `equinix.cloud` collection is an Equinix Metal-maintained collection.
 
 ## Submitting Issues
 All software has bugs, and the `equinix.cloud` collection is no exception. When you find a bug, 
-you can help tremendously by [telling us about it](https://github.com/equinix-labs/ansible-collection-metal/issues/new/choose).
+you can help tremendously by [telling us about it](https://github.com/equinix/ansible-collection-equinix/issues/new/choose).
 
 If you should discover that the bug you're trying to file already exists in an issue, 
 you can help by verifying the behavior of the reported bug with a comment in that 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,7 +26,7 @@ We use Python 3.8 for the collection development.
 Development of the collection is best done if your repository is located in a path that concludes with `ansible_collections/equinix/cloud`. This is a requirement specific to Ansible. You can clone the repository using the following command:
 
 ```
-git clone https://github.com/equinix-labs/ansible-collection-equinix ansible_collections/equinix/cloud
+git clone https://github.com/equinix/ansible-collection-equinix ansible_collections/equinix/cloud
 ```
 
 You also need to export your METAL_AUTH_TOKEN in the environment variables:
@@ -68,7 +68,7 @@ Just make sure you remove all the "q" calls before merging to main.
 
 The primary task for this collection is the addition of new modules with the aim of achieving parity with the [Terraform Provider Equinix](https://github.com/equinix/terraform-provider-equinix). Each Terraform resource should have a corresponding module, and each needed datasource should have an accompanying `_info` module.
 
-For instance, the [equinix_metal_device resource](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_device) in Terraform Provider corresponds to the [metal_device resource](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_device.md) in this collection. In the same vein, the [equinix_metal_device datasource](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_device) correlates with the [metal_device_info module](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_device_info.md) in our collection.
+For instance, the [equinix_metal_device resource](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_device) in Terraform Provider corresponds to the [metal_device resource](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_device.md) in this collection. In the same vein, the [equinix_metal_device datasource](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_device) correlates with the [metal_device_info module](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_device_info.md) in our collection.
 
 Issues have been created for every plausible existing Terraform resource and datasource within this repository. If you decide to work on a new module, please assign the corresponding issue to yourself.
 
@@ -148,7 +148,7 @@ All the samples will be rendered in markdown docs visible in the GitHub repo, on
 
 ###  2.3. <a name='mainfunction'></a>main() function
 
-The collection is structured to maintain consistency in the `main()` function across all modules. Modifications to the `main()` logic are only necessary for non-standard behavior. For instance, the `backend_transfer` attribute of the Project resource cannot be specified in the API call that creates a Project. As a result, we need to extend the `main()` function of the [metal_project module](https://github.com/equinix-labs/ansible-collection-equinix/blob/10fca6a7e1ea06b86204fd301454ab9eff254ef5/plugins/modules/metal_project.py#L256) to accommodate this.
+The collection is structured to maintain consistency in the `main()` function across all modules. Modifications to the `main()` logic are only necessary for non-standard behavior. For instance, the `backend_transfer` attribute of the Project resource cannot be specified in the API call that creates a Project. As a result, we need to extend the `main()` function of the [metal_project module](https://github.com/equinix/ansible-collection-equinix/blob/10fca6a7e1ea06b86204fd301454ab9eff254ef5/plugins/modules/metal_project.py#L256) to accommodate this.
 
 The module initialization leverages the parameter specification from SPECDOC_META.ansible_spec. This is where ansible-specdoc proves beneficial, as it eliminates the redundancy that would occur in the parameter specification documentation with standard Ansible use.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide: equinix.metal to equinix.cloud
 
-This migration guide is designed to help you transition from the [equinix.metal Ansible collection](https://github.com/equinix/ansible-collection-metal) to the newer [equinix.cloud collection](https://github.com/equinix-labs/ansible-collection-equinix) (on GitHub as [equinix-labs/ansible-collection-equinix](https://github.com/equinix-labs/ansible-collection-equinix)).
+This migration guide is designed to help you transition from the [equinix.metal Ansible collection](https://github.com/equinix/ansible-collection-metal) to the newer [equinix.cloud collection](https://github.com/equinix/ansible-collection-equinix) (on GitHub as [equinix/ansible-collection-equinix](https://github.com/equinix/ansible-collection-equinix)).
 
 ## Pre-Migration Checklist
 
@@ -10,7 +10,7 @@ This migration guide is designed to help you transition from the [equinix.metal 
 
 ## Installing equinix.cloud Collection
 
-Follow instructions on https://github.com/equinix-labs/ansible-collection-equinix#installation
+Follow instructions on https://github.com/equinix/ansible-collection-equinix#installation
 
 ## Authentication changes
 
@@ -30,20 +30,20 @@ export METAL_AUTH_TOKEN=your_api_token_here
 
 | equinix.metal Module                                                                                              | equinix.cloud Equivalent                                                                                              |
 |-------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| [equinix.metal.capacity_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.capacity_info_module.rst)                     | Not present in the new collection yet, [issue #135](https://github.com/equinix-labs/ansible-collection-equinix/issues/135)  |
-| [equinix.metal.device](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.device_module.rst)                              | [equinix.cloud.metal_device](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_device.md)                              |
-| [equinix.metal.device_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.device_info_module.rst)                        | [equinix.cloud.metal_device_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_device_info.md)                         |
+| [equinix.metal.capacity_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.capacity_info_module.rst)                     | Not present in the new collection yet, [issue #135](https://github.com/equinix/ansible-collection-equinix/issues/135)  |
+| [equinix.metal.device](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.device_module.rst)                              | [equinix.cloud.metal_device](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_device.md)                              |
+| [equinix.metal.device_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.device_info_module.rst)                        | [equinix.cloud.metal_device_info](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_device_info.md)                         |
 | [equinix.metal.facility_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.facility_info_module.rst)                      | "facility" is not a platform feature anymore        |
-| [equinix.metal.ip_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.ip_info_module.rst)                                | [equinix.cloud.metal_reserved_ip_block_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_reserved_ip_block_info.md)                   |
-| [equinix.metal.ip_subnet](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.ip_subnet_module.rst)                            | [equinix.cloud.metal_reserved_ip_block](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_reserved_ip_block.md)                           |
-| [equinix.metal.operating_system_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.operating_system_info_module.rst)      | [equinix.cloud.metal_operating_system_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_operating_system_info.md)             |
-| [equinix.metal.org_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.org_info_module.rst)                               | [equinix.cloud.metal_organization_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_organization_info.md)                      |
-| [equinix.metal.plan_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.plan_info_module.rst)                             | Not present in the new collection yet, [issue #136](https://github.com/equinix-labs/ansible-collection-equinix/issues/136)      |
-| [equinix.metal.project](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.project_module.rst)                                | [equinix.cloud.metal_project](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_project.md)                                |
-| [equinix.metal.project_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.project_info_module.rst)                       | [equinix.cloud.metal_project_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_project_info.md)                       |
-| [equinix.metal.sshkey](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.sshkey_module.rst)                                   | [equinix.cloud.metal_ssh_key](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_ssh_key.md)                                   |
-| [equinix.metal.sshkey_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.sshkey_info_module.rst)                         | [equinix.cloud.metal_ssh_key_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/main/docs/modules/metal_ssh_key_info.md)                         |
-| [equinix.metal.user_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.user_info_module.rst)                             | Not present in the new collection yes, [issue #137](https://github.com/equinix-labs/ansible-collection-equinix/issues/137)                         |
+| [equinix.metal.ip_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.ip_info_module.rst)                                | [equinix.cloud.metal_reserved_ip_block_info](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_reserved_ip_block_info.md)                   |
+| [equinix.metal.ip_subnet](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.ip_subnet_module.rst)                            | [equinix.cloud.metal_reserved_ip_block](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_reserved_ip_block.md)                           |
+| [equinix.metal.operating_system_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.operating_system_info_module.rst)      | [equinix.cloud.metal_operating_system_info](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_operating_system_info.md)             |
+| [equinix.metal.org_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.org_info_module.rst)                               | [equinix.cloud.metal_organization_info](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_organization_info.md)                      |
+| [equinix.metal.plan_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.plan_info_module.rst)                             | Not present in the new collection yet, [issue #136](https://github.com/equinix/ansible-collection-equinix/issues/136)      |
+| [equinix.metal.project](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.project_module.rst)                                | [equinix.cloud.metal_project](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_project.md)                                |
+| [equinix.metal.project_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.project_info_module.rst)                       | [equinix.cloud.metal_project_info](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_project_info.md)                       |
+| [equinix.metal.sshkey](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.sshkey_module.rst)                                   | [equinix.cloud.metal_ssh_key](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_ssh_key.md)                                   |
+| [equinix.metal.sshkey_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.sshkey_info_module.rst)                         | [equinix.cloud.metal_ssh_key_info](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_ssh_key_info.md)                         |
+| [equinix.metal.user_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.user_info_module.rst)                             | Not present in the new collection yes, [issue #137](https://github.com/equinix/ansible-collection-equinix/issues/137)                         |
 
 
 ## Testing
@@ -53,7 +53,7 @@ After updating your playbooks, it's essential to test them in a non-production e
 ## Support and Additional Resources
 
 - Utilize the [Equinix Metal Community Slack](https://slack.equinixmetal.com/) and [Community Site](https://community.equinix.com/) for support and to engage with other users who have made similar migrations.
-- Keep an eye on the [Ansible Collection for Equinix GitHub repository](https://github.com/equinix-labs/ansible-collection-equinix) for updates, and submit new feature requests on the Equinix Metal Roadmap.
+- Keep an eye on the [Ansible Collection for Equinix GitHub repository](https://github.com/equinix/ansible-collection-equinix) for updates, and submit new feature requests on the Equinix Metal Roadmap.
 
 Remember that while the equinix.metal and equinix.cloud collections may be similar, there may be differences in functionality and features. Always refer to the official documentation for the most accurate and up-to-date information.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Equinix Ansible Collection
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-equinix.cloud-660198.svg?style=flat)](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/)
-![Tests](https://img.shields.io/github/actions/workflow/status/equinix-labs/ansible-collection-equinix/integration-tests.yml?branch=main)
+![Tests](https://img.shields.io/github/actions/workflow/status/equinix/ansible-collection-equinix/integration-tests.yml?branch=main)
 
 This is repository for Ansible collection registered in Ansible Galaxy as [equinix.cloud](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/). The collection contains various plugins for managing Equinix services.
 
@@ -23,21 +23,21 @@ Modules for managing Equinix infrastructure.
 
 Name | Description |
 --- | ------------ |
-[equinix.cloud.metal_bgp_session](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_bgp_session.md)|Manage BGP sessions in Equinix Metal|
-[equinix.cloud.metal_connection](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_connection.md)|Manage an Interconnection in Equinix Metal|
-[equinix.cloud.metal_device](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_device.md)|Create, update, or delete Equinix Metal devices|
-[equinix.cloud.metal_gateway](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_gateway.md)|Manage Metal Gateway in Equinix Metal|
-[equinix.cloud.metal_hardware_reservation](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_hardware_reservation.md)|Lookup a single hardware_reservation by ID in Equinix Metal|
-[equinix.cloud.metal_ip_assignment](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_ip_assignment.md)|Manage Equinix Metal IP assignments|
-[equinix.cloud.metal_organization](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_organization.md)|Lookup a single organization by ID in Equinix Metal|
-[equinix.cloud.metal_project](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project.md)|Manage Projects in Equinix Metal|
-[equinix.cloud.metal_project_bgp_config](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project_bgp_config.md)|Manage BGP Config for Equinix Metal Project|
-[equinix.cloud.metal_project_ssh_key](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project_ssh_key.md)|Manage a project ssh key in Equinix Metal|
-[equinix.cloud.metal_reserved_ip_block](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_reserved_ip_block.md)|Create/delete blocks of reserved IP addresses in a project.|
-[equinix.cloud.metal_ssh_key](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_ssh_key.md)|Manage personal SSH keys in Equinix Metal|
-[equinix.cloud.metal_virtual_circuit](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_virtual_circuit.md)|Manage a Virtual Circuit in Equinix Metal|
-[equinix.cloud.metal_vlan](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_vlan.md)|Manage a VLAN resource in Equinix Metal|
-[equinix.cloud.metal_vrf](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_vrf.md)|Manage a VRF resource in Equinix Metal|
+[equinix.cloud.metal_bgp_session](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_bgp_session.md)|Manage BGP sessions in Equinix Metal|
+[equinix.cloud.metal_connection](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_connection.md)|Manage an Interconnection in Equinix Metal|
+[equinix.cloud.metal_device](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_device.md)|Create, update, or delete Equinix Metal devices|
+[equinix.cloud.metal_gateway](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_gateway.md)|Manage Metal Gateway in Equinix Metal|
+[equinix.cloud.metal_hardware_reservation](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_hardware_reservation.md)|Lookup a single hardware_reservation by ID in Equinix Metal|
+[equinix.cloud.metal_ip_assignment](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_ip_assignment.md)|Manage Equinix Metal IP assignments|
+[equinix.cloud.metal_organization](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_organization.md)|Lookup a single organization by ID in Equinix Metal|
+[equinix.cloud.metal_project](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project.md)|Manage Projects in Equinix Metal|
+[equinix.cloud.metal_project_bgp_config](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project_bgp_config.md)|Manage BGP Config for Equinix Metal Project|
+[equinix.cloud.metal_project_ssh_key](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project_ssh_key.md)|Manage a project ssh key in Equinix Metal|
+[equinix.cloud.metal_reserved_ip_block](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_reserved_ip_block.md)|Create/delete blocks of reserved IP addresses in a project.|
+[equinix.cloud.metal_ssh_key](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_ssh_key.md)|Manage personal SSH keys in Equinix Metal|
+[equinix.cloud.metal_virtual_circuit](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_virtual_circuit.md)|Manage a Virtual Circuit in Equinix Metal|
+[equinix.cloud.metal_vlan](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_vlan.md)|Manage a VLAN resource in Equinix Metal|
+[equinix.cloud.metal_vrf](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_vrf.md)|Manage a VRF resource in Equinix Metal|
 
 
 ### Info Modules
@@ -46,25 +46,25 @@ Modules for retrieving information about existing Equinix infrastructure.
 
 Name | Description |
 --- | ------------ |
-[equinix.cloud.metal_available_ips_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_available_ips_info.md)|Get list of avialable IP addresses from a reserved IP block|
-[equinix.cloud.metal_bgp_session_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_bgp_session_info.md)|Gather information BGP sessions in Equinix Metal|
-[equinix.cloud.metal_connection_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_connection_info.md)|Gather information about Interconnections|
-[equinix.cloud.metal_device_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_device_info.md)|Select list of Equinix Metal devices|
-[equinix.cloud.metal_gateway_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_gateway_info.md)|Gather information about Metal Gateways|
-[equinix.cloud.metal_hardware_reservation_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_hardware_reservation_info.md)|Gather information about Equinix Metal hardware_reservations|
-[equinix.cloud.metal_ip_assignment_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_ip_assignment_info.md)|Gather IP address assignments for a device|
-[equinix.cloud.metal_metro_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_metro_info.md)|Gather information about Equinix Metal metros|
-[equinix.cloud.metal_operating_system_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_operating_system_info.md)|Gather information about Operating Systems available for devices in Equinix Metal|
-[equinix.cloud.metal_organization_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_organization_info.md)|Gather information about Equinix Metal organizations|
-[equinix.cloud.metal_plan_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_plan_info.md)|Gather information about Equinix Metal plans|
-[equinix.cloud.metal_project_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project_info.md)|Gather information about Equinix Metal projects|
-[equinix.cloud.metal_project_ssh_key_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project_ssh_key_info.md)|Gather project SSH keys.|
-[equinix.cloud.metal_reserved_ip_block_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_reserved_ip_block_info.md)|Gather list of reserved IP blocks|
-[equinix.cloud.metal_ssh_key_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_ssh_key_info.md)|Gather personal SSH keys|
-[equinix.cloud.metal_user_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_user_info.md)|Gather information about the current user for Equinix Metal|
-[equinix.cloud.metal_virtual_circuit_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_virtual_circuit_info.md)|Gather information about Equinix Metal Virtual Circuits|
-[equinix.cloud.metal_vlan_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_vlan_info.md)|Gather VLANs.|
-[equinix.cloud.metal_vrf_info](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_vrf_info.md)|Gather VRFs|
+[equinix.cloud.metal_available_ips_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_available_ips_info.md)|Get list of avialable IP addresses from a reserved IP block|
+[equinix.cloud.metal_bgp_session_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_bgp_session_info.md)|Gather information BGP sessions in Equinix Metal|
+[equinix.cloud.metal_connection_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_connection_info.md)|Gather information about Interconnections|
+[equinix.cloud.metal_device_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_device_info.md)|Select list of Equinix Metal devices|
+[equinix.cloud.metal_gateway_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_gateway_info.md)|Gather information about Metal Gateways|
+[equinix.cloud.metal_hardware_reservation_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_hardware_reservation_info.md)|Gather information about Equinix Metal hardware_reservations|
+[equinix.cloud.metal_ip_assignment_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_ip_assignment_info.md)|Gather IP address assignments for a device|
+[equinix.cloud.metal_metro_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_metro_info.md)|Gather information about Equinix Metal metros|
+[equinix.cloud.metal_operating_system_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_operating_system_info.md)|Gather information about Operating Systems available for devices in Equinix Metal|
+[equinix.cloud.metal_organization_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_organization_info.md)|Gather information about Equinix Metal organizations|
+[equinix.cloud.metal_plan_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_plan_info.md)|Gather information about Equinix Metal plans|
+[equinix.cloud.metal_project_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project_info.md)|Gather information about Equinix Metal projects|
+[equinix.cloud.metal_project_ssh_key_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_project_ssh_key_info.md)|Gather project SSH keys.|
+[equinix.cloud.metal_reserved_ip_block_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_reserved_ip_block_info.md)|Gather list of reserved IP blocks|
+[equinix.cloud.metal_ssh_key_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_ssh_key_info.md)|Gather personal SSH keys|
+[equinix.cloud.metal_user_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_user_info.md)|Gather information about the current user for Equinix Metal|
+[equinix.cloud.metal_virtual_circuit_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_virtual_circuit_info.md)|Gather information about Equinix Metal Virtual Circuits|
+[equinix.cloud.metal_vlan_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_vlan_info.md)|Gather VLANs.|
+[equinix.cloud.metal_vrf_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/modules/metal_vrf_info.md)|Gather VRFs|
 
 
 ### Inventory Plugins
@@ -73,7 +73,7 @@ Dynamically add Equinix infrastructure to an Ansible inventory.
 
 Name |
 --- |
-[equinix.cloud.metal_device](https://github.com/equinix-labs/ansible-collection-equinix/blob/v0.9.0/docs/inventory/metal_device.rst)|
+[equinix.cloud.metal_device](https://github.com/equinix/ansible-collection-equinix/blob/v0.9.0/docs/inventory/metal_device.rst)|
 
 
 <!--end collection content-->
@@ -90,7 +90,7 @@ The Python module dependencies are not installed by `ansible-galaxy`.  They can
 be manually installed using pip:
 
 ```shell
-pip install -r https://raw.githubusercontent.com/equinix-labs/ansible-collection-equinix/v0.9.0/requirements.txt
+pip install -r https://raw.githubusercontent.com/equinix/ansible-collection-equinix/v0.9.0/requirements.txt
 ```
 
 ## Usage
@@ -127,7 +127,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Releasing
 
-Go to [https://github.com/equinix-labs/ansible-collection-equinix/releases/new](https://github.com/equinix-labs/ansible-collection-equinix/releases/new) and create a new release from `main`. Don't choose an existing tag. Put version to the field for "Release title", for example `v0.1.2`. Don't add collection number to the Makefile.
+Go to [https://github.com/equinix/ansible-collection-equinix/releases/new](https://github.com/equinix/ansible-collection-equinix/releases/new) and create a new release from `main`. Don't choose an existing tag. Put version to the field for "Release title", for example `v0.1.2`. Don't add collection number to the Makefile.
 
 Add release notes in format of [Terraform Provider Equinix](https://github.com/equinix/terraform-provider-equinix/releases), with at least one of the sections (NOTES, FEATURES, BUG FIXES, ENHANCEMENTS).
 
@@ -135,7 +135,7 @@ Click "Publish release", and the manual part should be over.
 
 The release will create a tag, and we have a Github action in place that should create an Ansible Galaxy release. The script that creates tarball for Galay removes the first "v", so releasing `v0.1.2` should upload collection equinix.cloud version 0.1.2.
 
-Verify that the [releasing Github action](https://github.com/equinix-labs/ansible-collection-equinix/actions) succeeded.
+Verify that the [releasing Github action](https://github.com/equinix/ansible-collection-equinix/actions) succeeded.
 
 Verify that new version of [equinix.cloud](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/) is available in Ansible Galaxy.
 

--- a/examples/device_assign_ip/README.md
+++ b/examples/device_assign_ip/README.md
@@ -1,6 +1,6 @@
 # IP Assignment to Metal Device
 
-This example playbook demonstrates the use of `equinix.cloud.metal_*` modules to manage resources on Equinix Metal. The playbook is available on GitHub at https://github.com/equinix-labs/ansible-collection-equinix/tree/examples/device_assign_ip.
+This example playbook demonstrates the use of `equinix.cloud.metal_*` modules to manage resources on Equinix Metal. The playbook is available on GitHub at https://github.com/equinix/ansible-collection-equinix/tree/examples/device_assign_ip.
 
 ## Overview
 

--- a/template/README.template.md
+++ b/template/README.template.md
@@ -1,6 +1,6 @@
 # Equinix Ansible Collection
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-equinix.cloud-660198.svg?style=flat)](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/)
-![Tests](https://img.shields.io/github/actions/workflow/status/equinix-labs/ansible-collection-equinix/integration-tests.yml?branch=main)
+![Tests](https://img.shields.io/github/actions/workflow/status/equinix/ansible-collection-equinix/integration-tests.yml?branch=main)
 
 This is repository for Ansible collection registered in Ansible Galaxy as [equinix.cloud](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/). The collection contains various plugins for managing Equinix services.
 
@@ -23,7 +23,7 @@ Modules for managing Equinix infrastructure.
 
 Name | Description |
 --- | ------------ |
-{% for mod in modules %}[equinix.cloud.{{ mod.name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
+{% for mod in modules %}[equinix.cloud.{{ mod.name }}]({% if is_release %}https://github.com/equinix/ansible-collection-equinix/blob/v{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
 {% endfor %}
 
 ### Info Modules
@@ -32,7 +32,7 @@ Modules for retrieving information about existing Equinix infrastructure.
 
 Name | Description |
 --- | ------------ |
-{% for mod in info_modules %}[equinix.cloud.{{ mod.name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
+{% for mod in info_modules %}[equinix.cloud.{{ mod.name }}]({% if is_release %}https://github.com/equinix/ansible-collection-equinix/blob/v{{ collection_version }}/docs/modules/{{ mod.name }}.md{% else %}./docs/modules/{{ mod.name }}.md{% endif %})|{{ mod.description }}|
 {% endfor %}
 
 ### Inventory Plugins
@@ -41,7 +41,7 @@ Dynamically add Equinix infrastructure to an Ansible inventory.
 
 Name |
 --- |
-{% for name in inventory %}[equinix.cloud.{{ name }}]({% if is_release %}https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/docs/inventory/{{ name }}.rst{% else %}./docs/inventory/{{ name }}.rst{% endif %})|
+{% for name in inventory %}[equinix.cloud.{{ name }}]({% if is_release %}https://github.com/equinix/ansible-collection-equinix/blob/v{{ collection_version }}/docs/inventory/{{ name }}.rst{% else %}./docs/inventory/{{ name }}.rst{% endif %})|
 {% endfor %}
 
 <!--end collection content-->
@@ -58,7 +58,7 @@ The Python module dependencies are not installed by `ansible-galaxy`.  They can
 be manually installed using pip:
 
 ```shell
-pip install -r https://raw.githubusercontent.com/equinix-labs/ansible-collection-equinix/v{{collection_version}}/requirements.txt
+pip install -r https://raw.githubusercontent.com/equinix/ansible-collection-equinix/v{{collection_version}}/requirements.txt
 ```
 
 ## Usage
@@ -95,7 +95,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Releasing
 
-Go to [https://github.com/equinix-labs/ansible-collection-equinix/releases/new](https://github.com/equinix-labs/ansible-collection-equinix/releases/new) and create a new release from `main`. Don't choose an existing tag. Put version to the field for "Release title", for example `v0.1.2`. Don't add collection number to the Makefile.
+Go to [https://github.com/equinix/ansible-collection-equinix/releases/new](https://github.com/equinix/ansible-collection-equinix/releases/new) and create a new release from `main`. Don't choose an existing tag. Put version to the field for "Release title", for example `v0.1.2`. Don't add collection number to the Makefile.
 
 Add release notes in format of [Terraform Provider Equinix](https://github.com/equinix/terraform-provider-equinix/releases), with at least one of the sections (NOTES, FEATURES, BUG FIXES, ENHANCEMENTS).
 
@@ -103,7 +103,7 @@ Click "Publish release", and the manual part should be over.
 
 The release will create a tag, and we have a Github action in place that should create an Ansible Galaxy release. The script that creates tarball for Galay removes the first "v", so releasing `v0.1.2` should upload collection equinix.cloud version 0.1.2.
 
-Verify that the [releasing Github action](https://github.com/equinix-labs/ansible-collection-equinix/actions) succeeded.
+Verify that the [releasing Github action](https://github.com/equinix/ansible-collection-equinix/actions) succeeded.
 
 Verify that new version of [equinix.cloud](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/) is available in Ansible Galaxy.
 

--- a/template/galaxy.template.yml
+++ b/template/galaxy.template.yml
@@ -1,6 +1,6 @@
 namespace: equinix
 name: cloud
-version: {{ collection_version }}
+version: { { collection_version } }
 readme: README.md
 description: Equinix ansible collection
 authors:
@@ -9,18 +9,17 @@ license_file: LICENSE
 tags:
   - equinix
   - cloud
-repository: https://github.com/equinix-labs/ansible-collection-equinix
-documentation: https://github.com/equinix-labs/ansible-collection-equinix/blob/v{{ collection_version }}/README.md
-homepage: https://github.com/equinix-labs/ansible-collection-equinix
-issues: https://github.com/equinix-labs/ansible-collection-equinix/issues
+repository: https://github.com/equinix/ansible-collection-equinix
+documentation: https://github.com/equinix/ansible-collection-equinix/blob/v{{ collection_version }}/README.md
+homepage: https://github.com/equinix/ansible-collection-equinix
+issues: https://github.com/equinix/ansible-collection-equinix/issues
 build_ignore:
-  - '.gitignore'
-  - '.github'
-  - '.pylintrc'
-  - '*.tar.gz'
-  - 'Makefile'
-#  - 'template'
-  - 'tests'
-#  - 'scripts'
-  - 'venv'
-
+  - ".gitignore"
+  - ".github"
+  - ".pylintrc"
+  - "*.tar.gz"
+  - "Makefile"
+  #  - 'template'
+  - "tests"
+  #  - 'scripts'
+  - "venv"


### PR DESCRIPTION
This updates docs to link to this repo under github.com/equinix instead of github.com/equinix-labs.  This is being contributed with the `feat:` tag so that we can cut a release after moving the repo, which will propagate the following things to Ansible Galaxy:
- These docs updates
- The recent switch from `metal-python` to `equinix-sdk-python`