### PR TITLE
chore: remove references to metal slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,8 @@ For general information on running the integration tests see the
 especially the section on configuration for cloud tests.  For questions about writing tests the Equinix Metal community can
 be found as detailed below.
 
-
 ### Code of Conduct
+
 The `equinix.cloud` collection follows the Ansible project's 
 [Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html). 
 Please read and familiarize yourself with this document.
-
-### Contact Information
-If you require support, please email [support@equinixmetal.com](mailto:support@equinixmetal.com), visit the Equinix Metal IRC channel (#equinixmetal on freenode), subscribe to the [Equinix Metal Community Slack channel](https://slack.equinixmetal.com/) or post an issue within this repository.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,15 +45,13 @@ export METAL_AUTH_TOKEN=your_api_token_here
 | [equinix.metal.sshkey_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.sshkey_info_module.rst)                         | [equinix.cloud.metal_ssh_key_info](https://github.com/equinix/ansible-collection-equinix/blob/main/docs/modules/metal_ssh_key_info.md)                         |
 | [equinix.metal.user_info](https://github.com/equinix/ansible-collection-metal/blob/main/docs/equinix.metal.user_info_module.rst)                             | Not present in the new collection yes, [issue #137](https://github.com/equinix/ansible-collection-equinix/issues/137)                         |
 
-
 ## Testing
 
 After updating your playbooks, it's essential to test them in a non-production environment to ensure that all tasks execute as expected and that there are no issues with the new collection.
 
 ## Support and Additional Resources
 
-- Utilize the [Equinix Metal Community Slack](https://slack.equinixmetal.com/) and [Community Site](https://community.equinix.com/) for support and to engage with other users who have made similar migrations.
+- Utilize the [Equinix Community](https://community.equinix.com/) for support and to engage with other users who have made similar migrations.
 - Keep an eye on the [Ansible Collection for Equinix GitHub repository](https://github.com/equinix/ansible-collection-equinix) for updates, and submit new feature requests on the Equinix Metal Roadmap.
 
 Remember that while the equinix.metal and equinix.cloud collections may be similar, there may be differences in functionality and features. Always refer to the official documentation for the most accurate and up-to-date information.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Equinix Ansible Collection
+
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-equinix.cloud-660198.svg?style=flat)](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/)
 ![Tests](https://img.shields.io/github/actions/workflow/status/equinix/ansible-collection-equinix/integration-tests.yml?branch=main)
+[![Equinix Community](https://img.shields.io/badge/Equinix%20Community%20-%20%23E91C24?logo=equinixmetal)](https://community.equinix.com)
 
 This is repository for Ansible collection registered in Ansible Galaxy as [equinix.cloud](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/). The collection contains various plugins for managing Equinix services.
 
@@ -39,7 +41,6 @@ Name | Description |
 [equinix.cloud.metal_vlan](https://github.com/equinix/ansible-collection-equinix/blob/v0.10.0/docs/modules/metal_vlan.md)|Manage a VLAN resource in Equinix Metal|
 [equinix.cloud.metal_vrf](https://github.com/equinix/ansible-collection-equinix/blob/v0.10.0/docs/modules/metal_vrf.md)|Manage a VRF resource in Equinix Metal|
 
-
 ### Info Modules
 
 Modules for retrieving information about existing Equinix infrastructure.
@@ -66,7 +67,6 @@ Name | Description |
 [equinix.cloud.metal_vlan_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.10.0/docs/modules/metal_vlan_info.md)|Gather VLANs.|
 [equinix.cloud.metal_vrf_info](https://github.com/equinix/ansible-collection-equinix/blob/v0.10.0/docs/modules/metal_vrf_info.md)|Gather VRFs|
 
-
 ### Inventory Plugins
 
 Dynamically add Equinix infrastructure to an Ansible inventory.
@@ -74,7 +74,6 @@ Dynamically add Equinix infrastructure to an Ansible inventory.
 Name |
 --- |
 [equinix.cloud.metal_device](https://github.com/equinix/ansible-collection-equinix/blob/v0.10.0/docs/inventory/metal_device.rst)|
-
 
 <!--end collection content-->
 
@@ -94,6 +93,7 @@ pip install -r https://raw.githubusercontent.com/equinix/ansible-collection-equi
 ```
 
 ## Usage
+
 Once the Equinix Ansible collection is installed, it can be referenced by its [Fully Qualified Collection Namespace (FQCN)](https://github.com/ansible-collections/overview#terminology): `equinix.cloud.module_name`.
 
 In order to use this collection, you should have account in the relevant Equinix service. For example you should have an account in Equinix Metal to use the `metal_*` modules.
@@ -138,7 +138,6 @@ The release will create a tag, and we have a Github action in place that should 
 Verify that the [releasing Github action](https://github.com/equinix/ansible-collection-equinix/actions) succeeded.
 
 Verify that new version of [equinix.cloud](https://galaxy.ansible.com/ui/repo/published/equinix/cloud/) is available in Ansible Galaxy.
-
 
 ## Licensing
 


### PR DESCRIPTION
following suite with the [terraform repo](https://github.com/equinix/terraform-provider-equinix) i've also added an Equinix Community badge to this repo, removed references to the Metal Slack, and removed references to support in general. (Also cleaned up some minor markdownlint errors)